### PR TITLE
Adding dependencies information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,10 @@ If you are still interested in contributing, you may want to consider heading ov
 You should select an issue labeled with "help wanted".
 If an issue is also labeled with "good first issue", then it requires very little knowledge
 regarding the project - great for first time contributors!
+
+##Project dependencies
+
+To contribute this project you should have installed the following pakages:
+
+* [Unity 2018.2.1](https://unity3d.com/es/get-unity/download/archive) 
+* [Blender](https://www.blender.org/download/)


### PR DESCRIPTION
I add a dependencies section with information about the software needed in order to contribute this project.
I would like to have these data handy, I download the project for studying one of the issues for hacktoberfest and I found I have to download another version of unity and blender. I think these data should be clear before start contributing this project.